### PR TITLE
use stable TSD 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-tsd",
   "description": "Grunt plugin to run TSD",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/DefinitelyTyped/grunt-tsd",
   "author": {
     "name": "Bart van der Schoor",
@@ -33,7 +33,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "tsd": "0.6.0-beta.5"
+    "tsd": "0.6.3"
   },
   "devDependencies": {
     "q": "~0.9.7",


### PR DESCRIPTION
as tsd 0.6 is stable now i reckon this should be reflected in a stable grunt-tsd version
